### PR TITLE
Relaxing overly trict validation.

### DIFF
--- a/src/libcamera/camera.cpp
+++ b/src/libcamera/camera.cpp
@@ -1167,7 +1167,7 @@ int Camera::configure(CameraConfiguration *config)
 	for (auto it : *config)
 		it.setStream(nullptr);
 
-	if (config->validate() != CameraConfiguration::Valid) {
+	if (config->validate() == CameraConfiguration::Invalid) {
 		LOG(Camera, Error)
 			<< "Can't configure camera with invalid configuration";
 		return -EINVAL;


### PR DESCRIPTION
Validation check was flawed before - it only passed state 'Valid', but there was also the acceptable state 'Adjusted' that was wrongly seen as unacceptable.
This prevented the user from using specific color spaces.