### PR TITLE
Disabling debinning block for monochrome cameras

### DIFF
--- a/src/ipa/rpi/pisp/pisp.cpp
+++ b/src/ipa/rpi/pisp/pisp.cpp
@@ -987,7 +987,7 @@ void IpaPiSP::setStatsAndDebin()
 	pisp_be_global_config beGlobal;
 	be_->GetGlobal(beGlobal);
 
-	if (mode_.binX > 1 || mode_.binY > 1) {
+	if ((!monoSensor_) && (mode_.binX > 1 || mode_.binY > 1)) {
 		pisp_be_debin_config debin;
 
 		be_->GetDebin(debin);


### PR DESCRIPTION
Conditioning use of the "Debin" block on the given sensor not being monochrome.
The [documentation](https://datasheets.raspberrypi.com/camera/raspberry-pi-image-signal-processor-specification.pdf) (section 7.5.24) does not seem to explain why the debinning filter would be needed for monochrome sensors, and if it is applied needlessly it seems to make performance worse for pixel-sensitive applications such as UVDAR.