### PR TITLE
Disable driver exclusivity

### DIFF
--- a/src/libcamera/camera_manager.cpp
+++ b/src/libcamera/camera_manager.cpp
@@ -250,9 +250,9 @@ CameraManager *CameraManager::self_ = nullptr;
 CameraManager::CameraManager()
 	: Extensible(std::make_unique<CameraManager::Private>())
 {
-	if (self_)
-		LOG(Camera, Fatal)
-			<< "Multiple CameraManager objects are not allowed";
+	/* if (self_) */
+	/* 	LOG(Camera, Fatal) */
+	/* 		<< "Multiple CameraManager objects are not allowed"; */
 
 	self_ = this;
 }

--- a/src/libcamera/ipa_manager.cpp
+++ b/src/libcamera/ipa_manager.cpp
@@ -105,9 +105,9 @@ IPAManager *IPAManager::self_ = nullptr;
  */
 IPAManager::IPAManager()
 {
-	if (self_)
-		LOG(IPAManager, Fatal)
-			<< "Multiple IPAManager objects are not allowed";
+	/* if (self_) */
+	/* 	LOG(IPAManager, Fatal) */
+	/* 		<< "Multiple IPAManager objects are not allowed"; */
 
 #if HAVE_IPA_PUBKEY
 	if (!pubKey_.isValid())

--- a/src/libcamera/process.cpp
+++ b/src/libcamera/process.cpp
@@ -114,9 +114,9 @@ ProcessManager *ProcessManager::self_ = nullptr;
  */
 ProcessManager::ProcessManager()
 {
-	if (self_)
-		LOG(Process, Fatal)
-			<< "Multiple ProcessManager objects are not allowed";
+	/* if (self_) */
+	/* 	LOG(Process, Fatal) */
+	/* 		<< "Multiple ProcessManager objects are not allowed"; */
 
 	sigaction(SIGCHLD, NULL, &oldsa_);
 


### PR DESCRIPTION
There are specific places in the code that prevent multiple instances of the driver being run at the same time in the same program.
Because of this, it was impossible to run more than one camera driver nodelet that we derive from this repository, since if each of them is a nodelet, their global objects overlap in the nodelet manager they use and thus they trigger the exclusivity mechanism.

Though these safeguards are probably intended to avoid blunders when programming the upstream driver itself, in practice each of the objects that are thus made exlusive only gets instantiated once within the overall `libcamera` object. Additionally, running the drivers as separate programs (or one as a nodelet under a shared manager and another as a standalone node) works without issues, which means that at least interfacing with the cameras and the interstital hardware by two instances of the software works fine.
Because of this, I've disabled the exlusivity mechanisms in the code. Testing shows that running two cameras at once, each with a driver as a nodelet under shared manager works well.